### PR TITLE
Reuse webasm. Don't recompile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -60,6 +60,11 @@ end</div>
   var runId = 0;
   var curId = 0;
   var ansi_up = new AnsiUp;
+  var sorbetModuleCompile = fetch('sorbet.wasm').then(response =>
+    response.arrayBuffer()
+  ).then(bytes =>
+    WebAssembly.compile(bytes)
+  )
 
   var print = function(line) {
     if (runId != curId) {
@@ -106,6 +111,11 @@ end</div>
         line = line.replace(/http:\/\/[^ ]*/, '')
         line = line.replace('git.corp.stripe.com/stripe-internal', 'github.com/stripe')
         print(line);
+      },
+      instantiateWasm: function(info, realRecieveInstanceCallBack) {
+        sorbetModuleCompile.then(module => WebAssembly.instantiate(module, info).then(instance =>
+          realRecieveInstanceCallBack(instance, module)).catch(error => console.error(error)))
+        return {}; // indicates lazy initialization
       },
     };
 


### PR DESCRIPTION
Found this option while reading implementation of emscripten.

Allows us to:
 - download wasm only once;
 - compile it only once;
 - instantiate it multiple times;