### PR TITLE
Fix broken 'Generic method' example

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -100,7 +100,7 @@ html, body {
     </li><li>
       <a href="#class%20Box%0A%20%20extend%20T%3A%3AGeneric%0A%0A%20%20Elem%20%3D%20type_member%0A%0A%20%20sig.returns(Elem)%0A%20%20attr_reader%20%3Ax%0A%0A%20%20sig(x%3A%20Elem).returns(Elem)%0A%20%20attr_writer%20%3Ax%0Aend%0A%0ABox%5BInteger%5D.new.x%20%2B%20Box%5BString%5D.new.x">Generic class</a>
     </li><li>
-      <a href="https://sorbet.run/#class%20Box%0A%20%20extend%20T%3A%3AGeneric%0A%20%0A%20%20Elem%20%3D%20type_member%0A%20%0A%20%20sig(x%3A%20Elem).void%0A%20%20def%20initialize(x)%0A%20%20%20%20%40x%3Dx%0A%20%20end%0A%20%0A%20%20type_parameters(%3AU).sig(%0A%20%20%20%20blk%3A%20T.proc(arg0%3A%20Elem).returns(T.type_parameter(%3AU))%2C%0A%20%20)%0A%20%20.returns(Box%5BT.type_parameter(%3AU)%5D)%0A%20%20def%20map(%26blk)%0A%20%20%20%20Box.new(blk.call(%40x))%0A%20%20end%0Aend%0A%20%0ABox%5BInteger%5D.new(0).map(%26%3Asucc)">Generic method</a>
+      <a href="#class%20Box%0A%20%20extend%20T%3A%3AGeneric%0A%20%0A%20%20Elem%20%3D%20type_member%0A%20%0A%20%20sig(x%3A%20Elem).void%0A%20%20def%20initialize(x)%0A%20%20%20%20%40x%3Dx%0A%20%20end%0A%20%0A%20%20type_parameters(%3AU).sig(%0A%20%20%20%20blk%3A%20T.proc(arg0%3A%20Elem).returns(T.type_parameter(%3AU))%2C%0A%20%20)%0A%20%20.returns(Box%5BT.type_parameter(%3AU)%5D)%0A%20%20def%20map(%26blk)%0A%20%20%20%20Box.new(blk.call(%40x))%0A%20%20end%0Aend%0A%20%0ABox%5BInteger%5D.new(0).map(%26%3Asucc)">Generic method</a>
     </li><li>
       <a href="#foo%20%3D%20'1'%0A%0A2%20%2B%20foo%0A2%20%2B%20T.unsafe(foo)%20%23%20an%20escape%20hatch%20tells%20the%20typechecker%20to%20allow%20anything">Escape hatch</a>
     </li><li>


### PR DESCRIPTION
[Rendered](https://sorbet.run/#class%20Box%0A%20%20extend%20T%3A%3AGeneric%0A%20%0A%20%20Elem%20%3D%20type_member%0A%20%0A%20%20sig(x%3A%20Elem).void%0A%20%20def%20initialize(x)%0A%20%20%20%20%40x%3Dx%0A%20%20end%0A%20%0A%20%20type_parameters(%3AU).sig(%0A%20%20%20%20blk%3A%20T.proc(arg0%3A%20Elem).returns(T.type_parameter(%3AU))%2C%0A%20%20)%0A%20%20.returns(Box%5BT.type_parameter(%3AU)%5D)%0A%20%20def%20map(%26blk)%0A%20%20%20%20Box.new(blk.call(%40x))%0A%20%20end%0Aend%0A%20%0ABox%5BInteger%5D.new(0).map(%26%3Asucc))