### PR TITLE
Add an option to change the title

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -253,6 +253,8 @@ a[data-href^="inmemory://model/"] {
           </li><li>
             <a href="#" id="vim-button">Toggle Vim keybindings</a>
           </li><li>
+            <a href="#" id="change-title">Change Title</a>
+          </li><li>
             <a href="#" id="create-issue-from-example">Create issue with example</a>
           </li>
         </ul>
@@ -277,11 +279,16 @@ if (window.top != window.self) {
 <script src="monaco/lib/main.bundle.js"></script>
 <script>
   (function() {
-    var button = document.getElementById('toggle-editor-only');
-    button.addEventListener('click', function(ev) {
+    var toggleEditorButton = document.getElementById('toggle-editor-only');
+    toggleEditorButton.addEventListener('click', function(ev) {
       ev.preventDefault();
       document.getElementById('editor').classList.toggle('editor-only');
       document.getElementById('output').classList.toggle('editor-only');
+    });
+    var changeTitleButton = document.getElementById('change-title');
+    changeTitleButton.addEventListener('click', function(ev) {
+      ev.preventDefault();
+      document.title = prompt('Enter a new title:') + " - Sorbet Playground";
     });
   })();
 </script>


### PR DESCRIPTION
When you have a lot of sorbet.run tabs open, it's hard to figure out which is which. This allows you change the tab title to a custom name, so you can distinguish them.